### PR TITLE
Serve built React client and enable Vite build

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "dev": "nodemon src/server.js",
     "start": "node src/server.js",
     "serve": "npm run start",
-    "build": "echo 'No build step required - static files ready'",
+    "build": "vite build",
     "verify": "node verify-setup.js",
     "load-sample": "node src/scripts/loadSampleData.js",
     "load-synthetic": "node src/scripts/loadSyntheticData.js",

--- a/src/server.js
+++ b/src/server.js
@@ -23,23 +23,19 @@ app.use(cors({
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
 
-// Handle root route BEFORE static files to override index.html
-app.get('/', (req, res) => {
-  // Prevent caching to ensure fresh loads
-  res.setHeader('Cache-Control', 'no-cache, no-store, must-revalidate');
-  res.setHeader('Pragma', 'no-cache');
-  res.setHeader('Expires', '0');
-  res.sendFile(path.join(__dirname, '../public/clinician-dashboard.html'));
-});
-
-app.use(express.static('public'));
-app.use('/data', express.static(path.join(__dirname, 'data')));
-
+// API routes
 app.use('/api/patients', patientRoutes);
 app.use('/api/reports', reportRoutes);
 app.use('/api/datasources', dataSourceRoutes);
 app.use('/api/longitudinal', longitudinalRoutes);
 app.use('/api', searchRoutes);
+
+// Static assets
+const distPath = path.join(__dirname, '../dist');
+const publicPath = path.join(__dirname, '../public');
+app.use(express.static(distPath));
+app.use(express.static(publicPath));
+app.use('/data', express.static(path.join(__dirname, 'data')));
 
 // Simple test endpoint
 app.get('/api/test', (req, res) => {
@@ -237,11 +233,16 @@ app.get('/api/test/patients', async (req, res) => {
   }
 });
 
+// Fallback for client-side routing
+app.get('*', (req, res) => {
+  res.sendFile(path.join(distPath, 'index.html'));
+});
+
 app.use((err, req, res, next) => {
   console.error(err.stack);
-  res.status(500).json({ 
+  res.status(500).json({
     error: 'Something went wrong!',
-    message: err.message 
+    message: err.message
   });
 });
 


### PR DESCRIPTION
## Summary
- use Vite for the main build script
- serve compiled assets from `dist` and fallback to the built `index.html`

## Testing
- `npm test` *(fails: No tests found, exiting with code 1)*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b0c82497608328bed0e19d20ebb7cb