### PR TITLE
Diagnose and fix build error

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -30,6 +30,11 @@ app.use('/api/datasources', dataSourceRoutes);
 app.use('/api/longitudinal', longitudinalRoutes);
 app.use('/api', searchRoutes);
 
+// Default route: serve clinician dashboard
+app.get('/', (req, res) => {
+  res.sendFile(path.join(__dirname, '../public', 'clinician-dashboard.html'));
+});
+
 // Static assets
 const distPath = path.join(__dirname, '../dist');
 const publicPath = path.join(__dirname, '../public');


### PR DESCRIPTION
Add an explicit root route to serve the clinician dashboard, fixing the issue where the React hub loaded instead of the intended dashboard.

---
<a href="https://cursor.com/background-agent?bcId=bc-fd9fcb8c-2ff9-44cb-ac3b-924960c1f935">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-fd9fcb8c-2ff9-44cb-ac3b-924960c1f935">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

